### PR TITLE
Expose Ciphertext copy constructor

### DIFF
--- a/SEALPython/wrapper.cpp
+++ b/SEALPython/wrapper.cpp
@@ -148,6 +148,7 @@ PYBIND11_MODULE(seal, m) {
 
   py::class_<Ciphertext>(m, "Ciphertext")
     .def(py::init<>())
+    .def(py::init<const Ciphertext &>())
     .def(py::init<const MemoryPoolHandle &>())
     .def(py::init<const EncryptionParameters &, const MemoryPoolHandle &>())
     .def(py::init<const EncryptionParameters &>())


### PR DESCRIPTION
This PR allows copying Ciphertext objects, which is necessary for certain calculations such as the "rotate and sum" method for adding up the slots of a ciphertext.