### PR TITLE
Fixed syntactical errors in run-docker.sh and wrapper.cpp

### DIFF
--- a/run-docker.sh
+++ b/run-docker.sh
@@ -1,4 +1,2 @@
 #!/bin/bash
-# docker run -it seal bash
-# docker run -it seal ./bin/sealexamples
-docker run -it seal-io python3 SEALPythonExamples/examples.py
+docker run -it seal-save python3 SEALPythonExamples/examples.py


### PR DESCRIPTION
Fixed syntactical errors in `run-docker.sh` and `/SEALPython/wrapper.cpp.`
    
Added pickle serialization for `PublicKey`, `SecretKey`, `EncryptionParameters` and granted access to 192 bit coefficient moduli.
    
Added neat serialization and deserialization functions for pickle to improve readability
