### PR TITLE
Add serialization for Plaintext

### DIFF
--- a/SEAL/seal/plaintext.cpp
+++ b/SEAL/seal/plaintext.cpp
@@ -345,6 +345,13 @@ namespace seal
         stream.write(reinterpret_cast<const char*>(plaintext_poly_.get()), coeff_count_ * bytes_per_uint64);
     }
 
+    void Plaintext::python_save(std::string &path) const
+    {
+        std::ofstream out(path);
+        save(out);
+        out.close();
+    }
+
     void Plaintext::load(istream &stream)
     {
         int32_t read_coeff_count = 0;
@@ -355,5 +362,12 @@ namespace seal
         
         // Read data
         stream.read(reinterpret_cast<char*>(plaintext_poly_.get()), read_coeff_count * bytes_per_uint64);
+    }
+
+    void Plaintext::python_load(std::string &path)
+    {
+        std::ifstream in(path);
+        load(in);
+        in.close();
     }
 }

--- a/SEAL/seal/plaintext.h
+++ b/SEAL/seal/plaintext.h
@@ -2,6 +2,7 @@
 
 #include <string>
 #include <iostream>
+#include <fstream>
 #include "seal/memorypoolhandle.h"
 #include "seal/bigpoly.h"
 #include "seal/encryptionparams.h"
@@ -687,6 +688,7 @@ namespace seal
         @see load() to load a saved plaintext.
         */
         void save(std::ostream &stream) const;
+        void python_save(std::string &path) const;
 
         /**
         Loads a Plaintext from an input stream overwriting the current plaintext.
@@ -695,6 +697,7 @@ namespace seal
         @see save() to save a plaintext.
         */
         void load(std::istream &stream);
+        void python_load(std::string &path);
 
     private:
         MemoryPoolHandle pool_;

--- a/SEALPython/wrapper.cpp
+++ b/SEALPython/wrapper.cpp
@@ -420,7 +420,11 @@ PYBIND11_MODULE(seal, m) {
      .def("to_string", &Plaintext::to_string, "Returns the plaintext as a formatted string")
      .def("coeff_count", &Plaintext::coeff_count, "Returns the coefficient count of the current plaintext polynomial")
      .def("coeff_at", &Plaintext::coeff_at, "Returns coefficient at a given index")
-     .def(py::pickle(&serialize<Plaintext>, &deserialize<Plaintext> ));
+     .def(py::pickle(&serialize<Plaintext>, &deserialize<Plaintext> ))
+     .def("save", (void (Plaintext::*)(std::string &)) &Plaintext::python_save,
+        "Saves Plaintext object to file given filepath")
+     .def("load", (void (Plaintext::*)(std::string &)) &Plaintext::python_load,
+        "Loads Plaintext object from file given filepath");
 
   py::class_<PolyCRTBuilder>(m, "PolyCRTBuilder")
     .def(py::init<const SEALContext &, const MemoryPoolHandle &>())


### PR DESCRIPTION
The serialization to file for `Ciphertext`s was expanded to the `Plaintext`.