### PR TITLE
Upgrade Dockerfile to Ubuntu 18.04 (17.10 is not supported)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 #
 # Container to build Linux SEAL libraries, python wrapper, and examples
 #
-FROM ubuntu:17.10
+FROM ubuntu:18.04
 MAINTAINER Todd Stavish <toddstavish@gmail.com>
 
 # Install binary dependencies


### PR DESCRIPTION
Ubuntu 17.10 is not supported anymore, which causes _build-docker.sh_ to fail.
This is a single-line change, so it would be reasonable if you choose to close it and push the change without this PR :).